### PR TITLE
fix: Fixed scp-deploy action repo name in README YAML example

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ jobs:
       - run: npm run generate
       
       - name: Publish
-        uses: nogsantos/scp-deploy@master
+        uses: nogsantos/ssh-scp-deploy@master
         with:
           src: ./dist/*
           host: ${{ secrets.SSH_HOST }}


### PR DESCRIPTION
Repository name in the README example was spelled wrong and will cause an error with Github actions if used 'as-is'.